### PR TITLE
Show feature configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,9 @@ There are also useful console commands defined as services and tagged with
 
 ```
  feature-toggles
-  feature-toggles:configure-feature    Configures a feature
-  feature-toggles:migrate-dbal-schema  Migrates DBAL schema
+  feature-toggles:configure-feature           Configures a feature
+  feature-toggles:migrate-dbal-schema         Migrates DBAL schema
+  feature-toggles:show-feature-configuration  Shows a feature configuration
 ```
 
 For technical details, see

--- a/sources/Bundle/FeatureTogglesExtension.php
+++ b/sources/Bundle/FeatureTogglesExtension.php
@@ -7,6 +7,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Trompette\FeatureToggles\Console\ConfigureFeatureCommand;
 use Trompette\FeatureToggles\Console\MigrateDBALSchemaCommand;
+use Trompette\FeatureToggles\Console\ShowFeatureConfigurationCommand;
 use Trompette\FeatureToggles\DBAL\OnOffStrategyConfigurationRepository;
 use Trompette\FeatureToggles\DBAL\PercentageStrategyConfigurationRepository;
 use Trompette\FeatureToggles\DBAL\WhitelistStrategyConfigurationRepository;
@@ -89,6 +90,13 @@ class FeatureTogglesExtension extends Extension
             ->addArgument(new Reference(OnOffStrategyConfigurationRepository::class))
             ->addArgument(new Reference(WhitelistStrategyConfigurationRepository::class))
             ->addArgument(new Reference(PercentageStrategyConfigurationRepository::class))
+            ->addTag('console.command')
+        ;
+
+        $container
+            ->register(ShowFeatureConfigurationCommand::class, ShowFeatureConfigurationCommand::class)
+            ->addArgument(new Reference(FeatureRegistry::class))
+            ->addArgument(new Reference(ToggleRouter::class))
             ->addTag('console.command')
         ;
 

--- a/sources/Console/ShowFeatureConfigurationCommand.php
+++ b/sources/Console/ShowFeatureConfigurationCommand.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Trompette\FeatureToggles\Console;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Trompette\FeatureToggles\FeatureRegistry;
+use Trompette\FeatureToggles\ToggleRouter;
+
+class ShowFeatureConfigurationCommand extends Command
+{
+    /** @var FeatureRegistry */
+    private $featureRegistry;
+
+    /** @var ToggleRouter */
+    private $toggleRouter;
+
+    public function __construct(FeatureRegistry $featureRegistry, ToggleRouter $toggleRouter)
+    {
+        parent::__construct('feature-toggles:show-feature-configuration');
+
+        $this->featureRegistry = $featureRegistry;
+        $this->toggleRouter = $toggleRouter;
+    }
+
+    protected function configure()
+    {
+        $this->setDescription('Shows a feature configuration');
+        $this->setHelp('This command shows a feature configuration and can answer if a target has a feature.');
+        $this->addArgument('feature', InputArgument::REQUIRED, 'The feature name');
+        $this->addArgument('target', InputArgument::OPTIONAL, 'An optional target');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $feature = $input->getArgument('feature');
+        $target = $input->getArgument('target');
+
+        $exists = $this->featureRegistry->exists($feature);
+        $description = $exists ? $this->featureRegistry->getDefinition($feature)->getDescription() : '-';
+        $strategy = $exists ? $this->featureRegistry->getDefinition($feature)->getStrategy() : '-';
+
+        $output->writeln($this->getHelper('formatter')->formatBlock('Feature', 'comment', true));
+        $output->writeln([
+            "Name:        " . $this->formatValue($feature),
+            "Registered:  " . $this->formatValue($exists),
+            "Description: " . $this->formatValue($description),
+            "Strategy:    " . $this->formatValue($strategy),
+        ]);
+
+        $output->writeln($this->getHelper('formatter')->formatBlock('Configuration', 'comment', true));
+        $table = new Table($output);
+        $table->setHeaders(['Strategy', 'Parameter', 'Value']);
+        $table->setRows(iterator_to_array($this->generateRows($feature)));
+        $table->render();
+
+        if (null !== $target) {
+            $output->writeln($this->getHelper('formatter')->formatBlock('Target', 'comment', true));
+            $output->writeln(sprintf(
+                'Target %s %s feature %s.',
+                $this->formatValue($target),
+                $this->toggleRouter->hasFeature($target, $feature) ? 'has' : 'does not have',
+                $this->formatValue($feature)
+            ));
+        }
+
+        return 0;
+    }
+
+    private function generateRows(string $feature): \Generator
+    {
+        foreach ($this->toggleRouter->getFeatureConfiguration($feature) as $strategy => $configuration) {
+            foreach ($configuration as $key => $value) {
+                yield [$strategy, $key, $this->formatValue($value)];
+            }
+        }
+    }
+
+    private function formatValue($value): string
+    {
+        switch (true) {
+            case is_bool($value):
+                return $this->formatInfo($value ? 'yes' : 'no');
+
+            case is_scalar($value):
+                return $this->formatInfo((string) $value);
+
+            case is_array($value) && count($value) <= 2:
+                return $this->formatInfo(join(', ', $value));
+
+            case is_array($value) && count($value) > 2:
+                return $this->formatInfo(sprintf(
+                    '%s, ... (%d more)',
+                    join(', ', array_slice($value, 0, 2)),
+                    count($value) - 2
+                ));
+
+            default:
+                throw new \TypeError();
+        }
+    }
+
+    private function formatInfo(string $value): string
+    {
+        return "<info>$value</info>";
+    }
+}

--- a/sources/FeatureDefinition.php
+++ b/sources/FeatureDefinition.php
@@ -25,6 +25,11 @@ class FeatureDefinition
         return $this->name;
     }
 
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
     public function getStrategy(): string
     {
         return $this->strategy;

--- a/sources/OnOffStrategy/OnOff.php
+++ b/sources/OnOffStrategy/OnOff.php
@@ -14,6 +14,11 @@ class OnOff implements TogglingStrategy
         $this->configurationRepository = $configurationRepository;
     }
 
+    public function getConfiguration(string $feature): array
+    {
+        return ['enabled' => $this->configurationRepository->isEnabled($feature)];
+    }
+
     public function decideIfTargetHasFeature(string $target, string $feature): bool
     {
         return $this->configurationRepository->isEnabled($feature);

--- a/sources/PercentageStrategy/Percentage.php
+++ b/sources/PercentageStrategy/Percentage.php
@@ -14,6 +14,11 @@ class Percentage implements TogglingStrategy
         $this->configurationRepository = $configurationRepository;
     }
 
+    public function getConfiguration(string $feature): array
+    {
+        return ['percentage' => $this->configurationRepository->getPercentage($feature)];
+    }
+
     public function decideIfTargetHasFeature(string $target, string $feature): bool
     {
         $percentage = $this->configurationRepository->getPercentage($feature);

--- a/sources/ToggleRouter.php
+++ b/sources/ToggleRouter.php
@@ -43,6 +43,16 @@ class ToggleRouter
         }
     }
 
+    public function getFeatureConfiguration(string $feature): array
+    {
+        return array_map(
+            function (TogglingStrategy $strategy) use ($feature) {
+                return $strategy->getConfiguration($feature);
+            },
+            $this->strategies
+        );
+    }
+
     public function configureFeature(string $feature, string $strategy, string $method, $parameters = []): void
     {
         Assert::that($this->strategies)->keyExists($strategy, "$strategy is an invalid strategy");

--- a/sources/TogglingStrategy.php
+++ b/sources/TogglingStrategy.php
@@ -4,5 +4,7 @@ namespace Trompette\FeatureToggles;
 
 interface TogglingStrategy
 {
+    public function getConfiguration(string $feature): array;
+
     public function decideIfTargetHasFeature(string $target, string $feature): bool;
 }

--- a/sources/WhitelistStrategy/Whitelist.php
+++ b/sources/WhitelistStrategy/Whitelist.php
@@ -14,6 +14,11 @@ class Whitelist implements TogglingStrategy
         $this->configurationRepository = $configurationRepository;
     }
 
+    public function getConfiguration(string $feature): array
+    {
+        return ['whitelistedTargets' => $this->configurationRepository->getWhitelistedTargets($feature)];
+    }
+
     public function decideIfTargetHasFeature(string $target, string $feature): bool
     {
         $whitelistedTargets = $this->configurationRepository->getWhitelistedTargets($feature);

--- a/tests/Console/ShowFeatureConfigurationCommandTest.php
+++ b/tests/Console/ShowFeatureConfigurationCommandTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Test\Trompette\FeatureToggles\Console;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Trompette\FeatureToggles\Console\ShowFeatureConfigurationCommand;
+use PHPUnit\Framework\TestCase;
+use Trompette\FeatureToggles\FeatureDefinition;
+use Trompette\FeatureToggles\FeatureRegistry;
+use Trompette\FeatureToggles\ToggleRouter;
+
+class ShowFeatureConfigurationCommandTest extends TestCase
+{
+    public function testCommandCanBeExecutedWithAFeature()
+    {
+        $commandTester = new CommandTester($this->configureCommand($withTarget = false));
+        $commandTester->execute(['feature' => 'feature']);
+
+        $this->assertSame(0, $commandTester->getStatusCode());
+        $this->assertStringContainsString('Feature', $commandTester->getDisplay());
+        $this->assertStringContainsString('Configuration', $commandTester->getDisplay());
+        $this->assertStringNotContainsString('Target', $commandTester->getDisplay());
+    }
+
+    public function testCommandCanBeExecutedWithAFeatureAndATarget()
+    {
+        $commandTester = new CommandTester($this->configureCommand($withTarget = true));
+        $commandTester->execute(['feature' => 'feature', 'target' => 'target']);
+
+        $this->assertSame(0, $commandTester->getStatusCode());
+        $this->assertStringContainsString('Target', $commandTester->getDisplay());
+    }
+
+    private function configureCommand(bool $withTarget): ShowFeatureConfigurationCommand
+    {
+        $featureRegistry = new FeatureRegistry();
+        $featureRegistry->register(new FeatureDefinition('feature', 'awesome feature', 'dummy'));
+
+        $toggleRouter = $this->prophesize(ToggleRouter::class);
+        $toggleRouter->getFeatureConfiguration('feature')->willReturn(['dummy' => ['paramKey' => 'paramValue']]);
+        if ($withTarget) {
+            $toggleRouter->hasFeature('target', 'feature')->willReturn(true);
+        }
+
+        $command = new ShowFeatureConfigurationCommand($featureRegistry, $toggleRouter->reveal());
+        $command->setApplication(new Application());
+
+        return $command;
+    }
+}

--- a/tests/OnOffStrategy/OnOffTest.php
+++ b/tests/OnOffStrategy/OnOffTest.php
@@ -8,21 +8,28 @@ use Trompette\FeatureToggles\OnOffStrategy\OnOff;
 
 class OnOffTest extends TestCase
 {
+    public function testConfigurationCanBeRetrieved()
+    {
+        $onOff = $this->configureOnOff('feature', true);
+
+        $this->assertSame(['enabled' => true], $onOff->getConfiguration('feature'));
+    }
+
     public function testTargetDoesNotHaveFeatureWhenNotEnabled()
     {
-        $onOff = $this->configureEnabled('feature', false);
+        $onOff = $this->configureOnOff('feature', false);
 
         $this->assertFalse($onOff->decideIfTargetHasFeature('target', 'feature'));
     }
 
     public function testTargetHasFeatureWhenEnabled()
     {
-        $onOff = $this->configureEnabled('feature', 100);
+        $onOff = $this->configureOnOff('feature', true);
 
         $this->assertTrue($onOff->decideIfTargetHasFeature('target', 'feature'));
     }
 
-    private function configureEnabled(string $feature, bool $enabled): OnOff
+    private function configureOnOff(string $feature, bool $enabled): OnOff
     {
         $configurationRepository = $this->prophesize(ConfigurationRepository::class);
         $configurationRepository->isEnabled($feature)->willReturn($enabled);

--- a/tests/PercentageStrategy/PercentageTest.php
+++ b/tests/PercentageStrategy/PercentageTest.php
@@ -8,6 +8,13 @@ use Trompette\FeatureToggles\PercentageStrategy\Percentage;
 
 class PercentageTest extends TestCase
 {
+    public function testConfigurationCanBeRetrieved()
+    {
+        $percentage = $this->configurePercentage('feature', 25);
+
+        $this->assertSame(['percentage' => 25], $percentage->getConfiguration('feature'));
+    }
+
     public function testTargetDoesNotHaveFeatureWhenPercentageIs0()
     {
         $percentage = $this->configurePercentage('feature', 0);

--- a/tests/ToggleRouterTest.php
+++ b/tests/ToggleRouterTest.php
@@ -46,6 +46,13 @@ class ToggleRouterTest extends TestCase
         $this->assertFalse($router->hasFeature('target', 'feature'));
     }
 
+    public function testFeatureConfigurationCanBeRetrievedByStrategy()
+    {
+        $router = $this->configureToggleRouter(null, ['dummy' => new DummyStrategy()]);
+
+        $this->assertSame(['dummy' => ['key' => 'value']], $router->getFeatureConfiguration('feature'));
+    }
+
     public function testUnregisteredFeatureCanBeConfiguredByStrategy()
     {
         $this->expectExceptionMessage("configure('value', 'feature') not implemented");

--- a/tests/ToggleRouterTest.php
+++ b/tests/ToggleRouterTest.php
@@ -146,6 +146,11 @@ class DummyStrategy implements TogglingStrategy
         return true;
     }
 
+    public function getConfiguration(string $feature): array
+    {
+        return ['key' => 'value'];
+    }
+
     public function configure(string $value, string $feature): void
     {
         throw new \Exception(__METHOD__."('$value', '$feature') not implemented");

--- a/tests/WhitelistStrategy/WhitelistTest.php
+++ b/tests/WhitelistStrategy/WhitelistTest.php
@@ -8,6 +8,13 @@ use Trompette\FeatureToggles\WhitelistStrategy\Whitelist;
 
 class WhitelistTest extends TestCase
 {
+    public function testConfigurationCanBeRetrieved()
+    {
+        $whitelist = $this->configureWhitelist('feature', ['whitelisted']);
+
+        $this->assertSame(['whitelistedTargets' => ['whitelisted']], $whitelist->getConfiguration('feature'));
+    }
+
     public function testTargetDoesNotHaveFeatureWhenWhitelistIsEmpty()
     {
         $whitelist = $this->configureWhitelist('feature', []);


### PR DESCRIPTION
This PR introduces `feature-toggles:show-feature-configuration`:

```
Description:
  Shows a feature configuration

Usage:
  feature-toggles:show-feature-configuration <feature> [<target>]

Arguments:
  feature               The feature name
  target                An optional target

Options:
  [default options]

Help:
  This command shows a feature configuration and can answer if a target has a feature.
```

Ref: #2 