### PR TITLE
Update Symfony versions in Travis CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,9 @@ php:
 
 env:
     - SYMFONY_VERSION="3.4.*"
-    - SYMFONY_VERSION="4.3.*"
     - SYMFONY_VERSION="4.4.*"
-    - SYMFONY_VERSION="5.0.*"
     - SYMFONY_VERSION="5.1.*"
+    - SYMFONY_VERSION="5.2.*"
 
 before_install:
     - phpenv config-rm xdebug.ini || echo "xdebug not available"


### PR DESCRIPTION
- 3.4 is a Security fixes only release
- 4.4, 5.1 and 5.2 are maintained Symfony releases

See https://symfony.com/releases