### PR TITLE
Use less strict Composer version constraints

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -37,7 +37,7 @@ jobs:
         php-version: "${{ matrix.php-version }}"
 
     - name: "Validate composer.json and composer.lock"
-      run: "composer validate --strict"
+      run: "composer validate"
 
     - name: "Install dependencies and require Symfony version from matrix"
       run: "composer require --ansi --no-interaction --no-progress --no-suggest --optimize-autoloader --prefer-dist doctrine/dbal:${{ matrix.dbal-version }} symfony/symfony:${{ matrix.symfony-version }}"

--- a/composer.json
+++ b/composer.json
@@ -22,14 +22,14 @@
     "require": {
         "php": ">=7.3",
         "ext-pdo": "*",
-        "beberlei/assert": "^3.2",
-        "doctrine/dbal": "^2.12 || ^3.0",
-        "psr/log": "^1.1",
-        "symfony/config": "^3.4 || ^4.4 || ^5.2",
-        "symfony/console": "^3.4 || ^4.4 || ^5.2",
-        "symfony/dependency-injection": "^3.4 || ^4.4 || ^5.2",
-        "symfony/expression-language": "^3.4 || ^4.4 || ^5.2",
-        "symfony/http-kernel": "^3.4 || ^4.4 || ^5.2"
+        "beberlei/assert": ">=3.2",
+        "doctrine/dbal": ">=2.12",
+        "psr/log": ">=1.1",
+        "symfony/config": ">=3.4",
+        "symfony/console": ">=3.4",
+        "symfony/dependency-injection": ">=3.4",
+        "symfony/expression-language": ">=3.4",
+        "symfony/http-kernel": ">=3.4"
     },
     "require-dev": {
         "ext-sqlite3": "*",


### PR DESCRIPTION
A library should not constraint versions to be used by an application.

And there is already a better safety net, the matrix used by automated tests: https://github.com/trompette/php-feature-toggles/blob/4979ae933496eb58b7437a978b3092a9fc4baa79/.github/workflows/automated-tests.yml#L17-L28