### PR TITLE
Move optional dependencies to suggest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,16 @@
         "psr/log": ">=1.1",
         "symfony/config": ">=3.4",
         "symfony/console": ">=3.4",
-        "symfony/dependency-injection": ">=3.4",
-        "symfony/expression-language": ">=3.4",
-        "symfony/http-kernel": ">=3.4"
+        "symfony/expression-language": ">=3.4"
     },
     "require-dev": {
         "ext-sqlite3": "*",
-        "phpunit/phpunit": "^8.5"
+        "phpunit/phpunit": "^8.5",
+        "symfony/dependency-injection": ">=3.4",
+        "symfony/http-kernel": ">=3.4"
+    },
+    "suggest": {
+        "symfony/dependency-injection": "To use the provided bundle",
+        "symfony/http-kernel": "To use the provided bundle"
     }
 }


### PR DESCRIPTION
As stated in the readme, this is a standalone library that can be used without the Symfony Framework.

As a result, the provided bundle is not mandatory, and the dependencies `symfony/dependency-injection` and `symfony/http-kernel` are not required.