### PR TITLE
Improve ConfigureFeatureCommand help message

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ There are also useful console commands defined as services and tagged with
   feature-toggles:show-feature-configuration  Shows a feature configuration
 ```
 
+More information about the commands can be found in their help messages.
+
 For technical details, see
 [`FeatureTogglesExtension`](sources/Bundle/FeatureTogglesExtension.php) class.
 

--- a/sources/Console/ConfigureFeatureCommand.php
+++ b/sources/Console/ConfigureFeatureCommand.php
@@ -23,7 +23,25 @@ class ConfigureFeatureCommand extends Command
     protected function configure()
     {
         $this->setDescription('Configures a feature');
-        $this->setHelp('This command configures a feature for a strategy using the toggle router.');
+        $this->setHelp(
+<<<HELP
+The <info>%command.name%</info> command configures a feature for a strategy using the toggle router.
+
+To enable or disable <comment>feature</comment> with <comment>onoff</comment> strategy:
+
+  <info>%command.full_name% feature onoff on</info>
+  <info>%command.full_name% feature onoff off</info>
+
+To add or remove <comment>target</comment> from whitelist for <comment>feature</comment> with <comment>whitelist</comment> strategy:
+
+  <info>%command.full_name% feature whitelist allow target</info>
+  <info>%command.full_name% feature whitelist disallow target</info>
+
+To configure percentage for <comment>feature</comment> with <comment>percentage</comment> strategy:
+
+  <info>%command.full_name% feature percentage slide 50</info>
+HELP
+        );
         $this->addArgument('feature', InputArgument::REQUIRED, 'The feature name');
         $this->addArgument('strategy', InputArgument::REQUIRED, 'The strategy name');
         $this->addArgument('method', InputArgument::REQUIRED, 'The configuration method name');


### PR DESCRIPTION
Help screenshot:
![image](https://user-images.githubusercontent.com/181746/121813029-9c8cb980-cc6a-11eb-8711-a0c0e49362ee.png)

And add a line in readme to invite users to read help message of commands.

Closes https://github.com/trompette/php-feature-toggles/issues/11.