### PR TITLE
DoctrineMigrationsBundle integration

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         dbal-version:
           - "2.12.*"
-          - "3.0.*"
+          - "2.13.*"
         php-version:
           - "7.3"
           - "7.4"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "require-dev": {
         "ext-sqlite3": "*",
-        "doctrine/orm": ">=2.9",
+        "doctrine/orm": ">=2.8",
         "phpunit/phpunit": "^9.5",
         "phpspec/prophecy-phpunit": "^2.0",
         "symfony/dependency-injection": ">=4.4",

--- a/composer.json
+++ b/composer.json
@@ -30,12 +30,14 @@
     },
     "require-dev": {
         "ext-sqlite3": "*",
+        "doctrine/orm": ">=2.9",
         "phpunit/phpunit": "^9.5",
         "phpspec/prophecy-phpunit": "^2.0",
         "symfony/dependency-injection": ">=4.4",
         "symfony/http-kernel": ">=4.4"
     },
     "suggest": {
+        "doctrine/orm": "To benefit from automatic schema creation",
         "symfony/dependency-injection": "To use the provided bundle",
         "symfony/http-kernel": "To use the provided bundle"
     }

--- a/sources/Bundle/FeatureTogglesExtension.php
+++ b/sources/Bundle/FeatureTogglesExtension.php
@@ -13,6 +13,7 @@ use Trompette\FeatureToggles\DBAL\PercentageStrategyConfigurationRepository;
 use Trompette\FeatureToggles\DBAL\WhitelistStrategyConfigurationRepository;
 use Trompette\FeatureToggles\FeatureRegistry;
 use Trompette\FeatureToggles\OnOffStrategy\OnOff;
+use Trompette\FeatureToggles\ORM\SchemaSubscriber;
 use Trompette\FeatureToggles\PercentageStrategy\Percentage;
 use Trompette\FeatureToggles\ToggleRouter;
 use Trompette\FeatureToggles\WhitelistStrategy\Whitelist;
@@ -27,6 +28,7 @@ class FeatureTogglesExtension extends Extension
         $this->defineTogglingStrategies($config['doctrine_dbal_connection'], $container);
         $this->defineToggleRouter($container);
         $this->defineConsoleCommands($container);
+        $this->defineDoctrineEventSubscriber($container);
     }
 
     public function getConfiguration(array $config, ContainerBuilder $container)
@@ -111,6 +113,17 @@ class FeatureTogglesExtension extends Extension
             ->register(ConfigureFeatureCommand::class, ConfigureFeatureCommand::class)
             ->addArgument(new Reference(ToggleRouter::class))
             ->addTag('console.command')
+        ;
+    }
+
+    private function defineDoctrineEventSubscriber(ContainerBuilder $container): void
+    {
+        $container
+            ->register(SchemaSubscriber::class, SchemaSubscriber::class)
+            ->addArgument(new Reference(OnOffStrategyConfigurationRepository::class))
+            ->addArgument(new Reference(WhitelistStrategyConfigurationRepository::class))
+            ->addArgument(new Reference(PercentageStrategyConfigurationRepository::class))
+            ->addTag('doctrine.event_subscriber')
         ;
     }
 }

--- a/sources/DBAL/PercentageStrategyConfigurationRepository.php
+++ b/sources/DBAL/PercentageStrategyConfigurationRepository.php
@@ -3,23 +3,12 @@
 namespace Trompette\FeatureToggles\DBAL;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Schema\Column;
-use Doctrine\DBAL\Schema\Index;
-use Doctrine\DBAL\Schema\Table;
-use Doctrine\DBAL\Types\SmallIntType;
-use Doctrine\DBAL\Types\StringType;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
 use Trompette\FeatureToggles\PercentageStrategy\ConfigurationRepository;
 
-class PercentageStrategyConfigurationRepository implements ConfigurationRepository, SchemaMigrator
+class PercentageStrategyConfigurationRepository extends SchemaMigrator implements ConfigurationRepository
 {
-    /** @var Connection */
-    private $connection;
-
-    public function __construct(Connection $connection)
-    {
-        $this->connection = $connection;
-    }
-
     public function getPercentage(string $feature): int
     {
         $sql = 'select percentage from feature_toggles_percentage where feature = ?';
@@ -48,23 +37,19 @@ class PercentageStrategyConfigurationRepository implements ConfigurationReposito
         );
     }
 
-    public function migrateSchema(): void
+    public function configureSchema(Schema $schema, Connection $connection): void
     {
-        $schemaManager = $this->connection->getSchemaManager();
-
-        if ($schemaManager->tablesExist(['feature_toggles_percentage'])) {
+        if ($connection !== $this->connection) {
             return;
         }
 
-        $schemaManager->createTable(new Table(
-            'feature_toggles_percentage',
-            [
-                new Column('feature', new StringType()),
-                new Column('percentage', new SmallIntType()),
-            ],
-            [
-                new Index('feature_toggles_percentage_pk', ['feature'], true, true),
-            ]
-        ));
+        if ($schema->hasTable('feature_toggles_percentage')) {
+            return;
+        }
+
+        $table = $schema->createTable('feature_toggles_percentage');
+        $table->addColumn('feature', Types::STRING);
+        $table->addColumn('percentage', Types::SMALLINT);
+        $table->setPrimaryKey(['feature'], 'feature_toggles_percentage_pk');
     }
 }

--- a/sources/DBAL/SchemaConfigurator.php
+++ b/sources/DBAL/SchemaConfigurator.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Trompette\FeatureToggles\DBAL;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Schema;
+
+interface SchemaConfigurator
+{
+    public function configureSchema(Schema $schema, Connection $connection): void;
+}

--- a/sources/DBAL/SchemaMigrator.php
+++ b/sources/DBAL/SchemaMigrator.php
@@ -2,7 +2,27 @@
 
 namespace Trompette\FeatureToggles\DBAL;
 
-interface SchemaMigrator
+use Doctrine\DBAL\Connection;
+
+abstract class SchemaMigrator implements SchemaConfigurator
 {
-    public function migrateSchema(): void;
+    /** @var Connection */
+    protected $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function migrateSchema(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        $fromSchema = $this->connection->getSchemaManager()->createSchema();
+
+        $this->configureSchema($toSchema = clone $fromSchema, $this->connection);
+
+        foreach ($toSchema->getMigrateFromSql($fromSchema, $platform) as $statement) {
+            $this->connection->executeStatement($statement);
+        }
+    }
 }

--- a/sources/ORM/SchemaSubscriber.php
+++ b/sources/ORM/SchemaSubscriber.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Trompette\FeatureToggles\ORM;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+use Doctrine\ORM\Tools\ToolEvents;
+use Trompette\FeatureToggles\DBAL\SchemaConfigurator;
+
+class SchemaSubscriber implements EventSubscriber
+{
+    /** @var SchemaConfigurator[] */
+    private $configurators;
+
+    public function __construct(SchemaConfigurator ...$configurators)
+    {
+        $this->configurators = $configurators;
+    }
+
+    public function postGenerateSchema(GenerateSchemaEventArgs $eventArgs): void
+    {
+        $schema = $eventArgs->getSchema();
+        $connection = $eventArgs->getEntityManager()->getConnection();
+
+        foreach ($this->configurators as $configurator) {
+            $configurator->configureSchema($schema, $connection);
+        }
+    }
+
+    public function getSubscribedEvents(): array
+    {
+        // subscribe to event only if Doctrine ORM is installed
+        return class_exists(ToolEvents::class) ? [ToolEvents::postGenerateSchema] : [];
+    }
+}

--- a/tests/DBAL/OnOffStrategyConfigurationRepositoryTest.php
+++ b/tests/DBAL/OnOffStrategyConfigurationRepositoryTest.php
@@ -3,18 +3,32 @@
 namespace Test\Trompette\FeatureToggles\DBAL;
 
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Schema\Schema;
 use Trompette\FeatureToggles\DBAL\OnOffStrategyConfigurationRepository;
 use PHPUnit\Framework\TestCase;
 
 class OnOffStrategyConfigurationRepositoryTest extends TestCase
 {
+    public function testSchemaIsConfiguredForUnderlyingConnectionOnly()
+    {
+        $DBALConnection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
+        $repository = new OnOffStrategyConfigurationRepository($DBALConnection);
+        $repository->configureSchema($schema = new Schema(), $DBALConnection);
+
+        static::assertCount(1, $schema->getTables());
+
+        $otherDBALConnection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
+        $repository->configureSchema($schema = new Schema(), $otherDBALConnection);
+
+        static::assertEmpty($schema->getTables());
+    }
+
     public function testSchemaIsMigrated()
     {
         $DBALConnection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
         $repository = new OnOffStrategyConfigurationRepository($DBALConnection);
-
-        static::assertCount(0, $DBALConnection->getSchemaManager()->listTables());
         $repository->migrateSchema();
+
         static::assertCount(1, $DBALConnection->getSchemaManager()->listTables());
     }
 

--- a/tests/DBAL/WhitelistStrategyConfigurationRepositoryTest.php
+++ b/tests/DBAL/WhitelistStrategyConfigurationRepositoryTest.php
@@ -3,18 +3,33 @@
 namespace Test\Trompette\FeatureToggles\DBAL;
 
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Schema\Schema;
 use Trompette\FeatureToggles\DBAL\WhitelistStrategyConfigurationRepository;
 use PHPUnit\Framework\TestCase;
 
 class WhitelistStrategyConfigurationRepositoryTest extends TestCase
 {
+    public function testSchemaIsConfiguredForUnderlyingConnectionOnly()
+    {
+        $DBALConnection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
+        $repository = new WhitelistStrategyConfigurationRepository($DBALConnection);
+        $repository->configureSchema($schema = new Schema(), $DBALConnection);
+
+        static::assertCount(1, $schema->getTables());
+
+        $otherDBALConnection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
+        $repository->configureSchema($schema = new Schema(), $otherDBALConnection);
+
+        static::assertEmpty($schema->getTables());
+    }
+
+
     public function testSchemaIsMigrated()
     {
         $DBALConnection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
         $repository = new WhitelistStrategyConfigurationRepository($DBALConnection);
-
-        static::assertCount(0, $DBALConnection->getSchemaManager()->listTables());
         $repository->migrateSchema();
+
         static::assertCount(1, $DBALConnection->getSchemaManager()->listTables());
     }
 

--- a/tests/ORM/SchemaSubscriberTest.php
+++ b/tests/ORM/SchemaSubscriberTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Test\Trompette\FeatureToggles\ORM;
+
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+use Doctrine\ORM\Tools\ToolEvents;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Trompette\FeatureToggles\DBAL\SchemaConfigurator;
+use Trompette\FeatureToggles\ORM\SchemaSubscriber;
+
+class SchemaSubscriberTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testSchemaIsConfiguredAfterGeneration()
+    {
+        $schema = new Schema();
+        $connection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
+
+        $configurator = $this->prophesize(SchemaConfigurator::class);
+        $configurator->configureSchema($schema, $connection)->shouldBeCalled();
+
+        $connection->getEventManager()->addEventSubscriber(new SchemaSubscriber($configurator->reveal()));
+
+        $entityManager = $this->prophesize(EntityManagerInterface::class);
+        $entityManager->getConnection()->willReturn($connection);
+
+        $connection->getEventManager()->dispatchEvent(
+            ToolEvents::postGenerateSchema,
+            new GenerateSchemaEventArgs($entityManager->reveal(), $schema)
+        );
+    }
+}


### PR DESCRIPTION
This PR hooks into Doctrine ORM machinery to configure the DBAL schema as needed by the library.

As a result, the tables used by the library:
- can be created by a Doctrine migration generated with `docrine:migrations:diff`
- will be ignored by next migrations without using the `schema_filter` parameter

Closes #13.