### PR TITLE
Implement migrating a schema with tables already created

### DIFF
--- a/sources/DBAL/OnOffStrategyConfigurationRepository.php
+++ b/sources/DBAL/OnOffStrategyConfigurationRepository.php
@@ -57,7 +57,7 @@ class OnOffStrategyConfigurationRepository extends SchemaMigrator implements Con
         }
 
         if ($schema->hasTable('feature_toggles_onoff')) {
-            return;
+            $schema->dropTable('feature_toggles_onoff');
         }
 
         $table = $schema->createTable('feature_toggles_onoff');

--- a/sources/DBAL/PercentageStrategyConfigurationRepository.php
+++ b/sources/DBAL/PercentageStrategyConfigurationRepository.php
@@ -44,7 +44,7 @@ class PercentageStrategyConfigurationRepository extends SchemaMigrator implement
         }
 
         if ($schema->hasTable('feature_toggles_percentage')) {
-            return;
+            $schema->dropTable('feature_toggles_percentage');
         }
 
         $table = $schema->createTable('feature_toggles_percentage');

--- a/sources/DBAL/WhitelistStrategyConfigurationRepository.php
+++ b/sources/DBAL/WhitelistStrategyConfigurationRepository.php
@@ -38,7 +38,7 @@ class WhitelistStrategyConfigurationRepository extends SchemaMigrator implements
         }
 
         if ($schema->hasTable('feature_toggles_whitelist')) {
-            return;
+            $schema->dropTable('feature_toggles_whitelist');
         }
 
         $table = $schema->createTable('feature_toggles_whitelist');

--- a/tests/DBAL/ConfigurationRepositoryTest.php
+++ b/tests/DBAL/ConfigurationRepositoryTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Test\Trompette\FeatureToggles\DBAL;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Schema\Schema;
+use PHPUnit\Framework\TestCase;
+use Trompette\FeatureToggles\DBAL\SchemaMigrator;
+
+abstract class ConfigurationRepositoryTest extends TestCase
+{
+    /** @var Connection */
+    protected $connection;
+
+    /** @var SchemaMigrator */
+    protected $repository;
+
+    protected function setUp(): void
+    {
+        $this->connection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
+        $this->createRepository();
+    }
+
+    abstract protected function createRepository();
+
+    public function testSchemaIsConfiguredForUnderlyingConnectionOnly()
+    {
+        $this->repository->configureSchema($schema = new Schema(), $this->connection);
+        static::assertCount(1, $schema->getTables());
+
+        $anotherConnection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
+        $this->repository->configureSchema($schema = new Schema(), $anotherConnection);
+        static::assertEmpty($schema->getTables());
+    }
+
+    public function testSchemaIsMigrated()
+    {
+        $this->repository->migrateSchema();
+        static::assertCount(1, $this->connection->getSchemaManager()->listTables());
+    }
+}

--- a/tests/DBAL/OnOffStrategyConfigurationRepositoryTest.php
+++ b/tests/DBAL/OnOffStrategyConfigurationRepositoryTest.php
@@ -2,46 +2,24 @@
 
 namespace Test\Trompette\FeatureToggles\DBAL;
 
-use Doctrine\DBAL\DriverManager;
-use Doctrine\DBAL\Schema\Schema;
 use Trompette\FeatureToggles\DBAL\OnOffStrategyConfigurationRepository;
-use PHPUnit\Framework\TestCase;
 
-class OnOffStrategyConfigurationRepositoryTest extends TestCase
+class OnOffStrategyConfigurationRepositoryTest extends ConfigurationRepositoryTest
 {
-    public function testSchemaIsConfiguredForUnderlyingConnectionOnly()
+    protected function createRepository()
     {
-        $DBALConnection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
-        $repository = new OnOffStrategyConfigurationRepository($DBALConnection);
-        $repository->configureSchema($schema = new Schema(), $DBALConnection);
-
-        static::assertCount(1, $schema->getTables());
-
-        $otherDBALConnection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
-        $repository->configureSchema($schema = new Schema(), $otherDBALConnection);
-
-        static::assertEmpty($schema->getTables());
-    }
-
-    public function testSchemaIsMigrated()
-    {
-        $DBALConnection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
-        $repository = new OnOffStrategyConfigurationRepository($DBALConnection);
-        $repository->migrateSchema();
-
-        static::assertCount(1, $DBALConnection->getSchemaManager()->listTables());
+        $this->repository = new OnOffStrategyConfigurationRepository($this->connection);
     }
 
     public function testConfigurationIsPersisted()
     {
-        $DBALConnection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
-        $repository = new OnOffStrategyConfigurationRepository($DBALConnection);
-        $repository->migrateSchema();
+        $this->repository->migrateSchema();
+        static::assertFalse($this->repository->isEnabled('feature'));
 
-        static::assertFalse($repository->isEnabled('feature'));
-        $repository->setEnabled(true, 'feature');
-        static::assertTrue($repository->isEnabled('feature'));
-        $repository->setEnabled(false, 'feature');
-        static::assertFalse($repository->isEnabled('feature'));
+        $this->repository->setEnabled(true, 'feature');
+        static::assertTrue($this->repository->isEnabled('feature'));
+
+        $this->repository->setEnabled(false, 'feature');
+        static::assertFalse($this->repository->isEnabled('feature'));
     }
 }

--- a/tests/DBAL/PercentageStrategyConfigurationRepositoryTest.php
+++ b/tests/DBAL/PercentageStrategyConfigurationRepositoryTest.php
@@ -2,45 +2,21 @@
 
 namespace Test\Trompette\FeatureToggles\DBAL;
 
-use Doctrine\DBAL\DriverManager;
-use Doctrine\DBAL\Schema\Schema;
 use Trompette\FeatureToggles\DBAL\PercentageStrategyConfigurationRepository;
-use PHPUnit\Framework\TestCase;
 
-class PercentageStrategyConfigurationRepositoryTest extends TestCase
+class PercentageStrategyConfigurationRepositoryTest extends ConfigurationRepositoryTest
 {
-    public function testSchemaIsConfiguredForUnderlyingConnectionOnly()
+    protected function createRepository()
     {
-        $DBALConnection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
-        $repository = new PercentageStrategyConfigurationRepository($DBALConnection);
-        $repository->configureSchema($schema = new Schema(), $DBALConnection);
-
-        static::assertCount(1, $schema->getTables());
-
-        $otherDBALConnection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
-        $repository->configureSchema($schema = new Schema(), $otherDBALConnection);
-
-        static::assertEmpty($schema->getTables());
-    }
-
-
-    public function testSchemaIsMigrated()
-    {
-        $DBALConnection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
-        $repository = new PercentageStrategyConfigurationRepository($DBALConnection);
-        $repository->migrateSchema();
-
-        static::assertCount(1, $DBALConnection->getSchemaManager()->listTables());
+        $this->repository = new PercentageStrategyConfigurationRepository($this->connection);
     }
 
     public function testConfigurationIsPersisted()
     {
-        $DBALConnection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
-        $repository = new PercentageStrategyConfigurationRepository($DBALConnection);
-        $repository->migrateSchema();
+        $this->repository->migrateSchema();
+        static::assertSame(0, $this->repository->getPercentage('feature'));
 
-        static::assertSame(0, $repository->getPercentage('feature'));
-        $repository->setPercentage(25, 'feature');
-        static::assertSame(25, $repository->getPercentage('feature'));
+        $this->repository->setPercentage(25, 'feature');
+        static::assertSame(25, $this->repository->getPercentage('feature'));
     }
 }


### PR DESCRIPTION
This PR enables migrating a schema with tables needed by the library already created, either using `feature-toggles:migrate-dbal-schema` or generating a Doctrine migration with `docrine:migrations:diff`.

I do not plan on changing the underlying schema for persisting feature configurations, but now I can if I want to.

Closes #28.