### PR TITLE
Remove Doctrine DBAL deprecations

### DIFF
--- a/sources/DBAL/SchemaMigrator.php
+++ b/sources/DBAL/SchemaMigrator.php
@@ -16,7 +16,7 @@ abstract class SchemaMigrator implements SchemaConfigurator
     public function migrateSchema(): void
     {
         $platform = $this->connection->getDatabasePlatform();
-        $fromSchema = $this->connection->getSchemaManager()->createSchema();
+        $fromSchema = $this->connection->createSchemaManager()->createSchema();
 
         $this->configureSchema($toSchema = clone $fromSchema, $this->connection);
 

--- a/sources/DBAL/SchemaMigrator.php
+++ b/sources/DBAL/SchemaMigrator.php
@@ -15,13 +15,11 @@ abstract class SchemaMigrator implements SchemaConfigurator
 
     public function migrateSchema(): void
     {
-        $platform = $this->connection->getDatabasePlatform();
-        $fromSchema = $this->connection->createSchemaManager()->introspectSchema();
+        $schemaManager = $this->connection->createSchemaManager();
 
-        $this->configureSchema($toSchema = clone $fromSchema, $this->connection);
+        $schema = $schemaManager->introspectSchema();
+        $this->configureSchema($schema, $this->connection);
 
-        foreach ($toSchema->getMigrateFromSql($fromSchema, $platform) as $statement) {
-            $this->connection->executeStatement($statement);
-        }
+        $schemaManager->migrateSchema($schema);
     }
 }

--- a/sources/DBAL/SchemaMigrator.php
+++ b/sources/DBAL/SchemaMigrator.php
@@ -16,7 +16,7 @@ abstract class SchemaMigrator implements SchemaConfigurator
     public function migrateSchema(): void
     {
         $platform = $this->connection->getDatabasePlatform();
-        $fromSchema = $this->connection->createSchemaManager()->createSchema();
+        $fromSchema = $this->connection->createSchemaManager()->introspectSchema();
 
         $this->configureSchema($toSchema = clone $fromSchema, $this->connection);
 

--- a/tests/Bundle/FeatureTogglesBundleTest.php
+++ b/tests/Bundle/FeatureTogglesBundleTest.php
@@ -55,7 +55,7 @@ class AppKernel extends Kernel
             $container
                 ->register('my_doctrine_dbal_connection', Connection::class)
                 ->setFactory([DriverManager::class, 'getConnection'])
-                ->setArguments([['url' => 'sqlite:///:memory:']])
+                ->setArguments([['driver' => 'pdo_sqlite', 'memory' => true]])
                 ->setPublic(true)
             ;
 

--- a/tests/DBAL/ConfigurationRepositoryTest.php
+++ b/tests/DBAL/ConfigurationRepositoryTest.php
@@ -41,15 +41,15 @@ abstract class ConfigurationRepositoryTest extends TestCase
         $schemaManager = $this->connection->createSchemaManager();
 
         $this->repository->migrateSchema();
-        $schema = $schemaManager->createSchema();
+        $schema = $schemaManager->introspectSchema();
         static::assertCount(1, $tables = $schema->getTables());
 
         $table = $schema->getTable((string) array_key_first($tables));
         $schemaManager->alterTable($this->createTableDiff($table));
-        static::assertNotEquals($schema, $schemaManager->createSchema());
+        static::assertNotEquals($schema, $schemaManager->introspectSchema());
 
         $this->repository->migrateSchema();
-        static::assertEquals($schema, $schemaManager->createSchema());
+        static::assertEquals($schema, $schemaManager->introspectSchema());
     }
 
     private function createTableDiff(Table $table): TableDiff

--- a/tests/DBAL/ConfigurationRepositoryTest.php
+++ b/tests/DBAL/ConfigurationRepositoryTest.php
@@ -20,7 +20,7 @@ abstract class ConfigurationRepositoryTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->connection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
+        $this->connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
         $this->createRepository();
     }
 
@@ -31,7 +31,7 @@ abstract class ConfigurationRepositoryTest extends TestCase
         $this->repository->configureSchema($schema = new Schema(), $this->connection);
         static::assertCount(1, $schema->getTables());
 
-        $anotherConnection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
+        $anotherConnection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
         $this->repository->configureSchema($schema = new Schema(), $anotherConnection);
         static::assertEmpty($schema->getTables());
     }

--- a/tests/DBAL/ConfigurationRepositoryTest.php
+++ b/tests/DBAL/ConfigurationRepositoryTest.php
@@ -38,7 +38,7 @@ abstract class ConfigurationRepositoryTest extends TestCase
 
     public function testAlteredSchemaCanBeMigrated(): void
     {
-        $schemaManager = $this->connection->getSchemaManager();
+        $schemaManager = $this->connection->createSchemaManager();
 
         $this->repository->migrateSchema();
         $schema = $schemaManager->createSchema();

--- a/tests/ORM/SchemaConfigurationListenerTest.php
+++ b/tests/ORM/SchemaConfigurationListenerTest.php
@@ -20,7 +20,7 @@ class SchemaConfigurationListenerTest extends TestCase
     public function testSchemaIsConfiguredAfterGeneration(): void
     {
         $schema = new Schema();
-        $connection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
+        $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
 
         $entityManager = $this->prophesize(EntityManagerInterface::class);
         $entityManager->getConnection()->willReturn($connection);

--- a/tests/ToggleRouterTest.php
+++ b/tests/ToggleRouterTest.php
@@ -163,7 +163,7 @@ class ToggleRouterTest extends TestCase
      */
     private function configureAllStrategies(): array
     {
-        $DBALConnection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
+        $DBALConnection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
 
         $onOffConfigurationRepository = new OnOffStrategyConfigurationRepository($DBALConnection);
         $onOffConfigurationRepository->migrateSchema();


### PR DESCRIPTION
To be able to support Doctrine DBAL 4.0, the library should not rely on API that are deprecated in Doctrine DBAL 3.8.

Ref: https://github.com/doctrine/dbal/blob/4.0.x/UPGRADE.md#upgrade-to-40