### PR TITLE
Clear unregistered features

### DIFF
--- a/sources/Bundle/FeatureTogglesExtension.php
+++ b/sources/Bundle/FeatureTogglesExtension.php
@@ -7,6 +7,7 @@ use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Trompette\FeatureToggles\Console\ClearUnregisteredFeaturesCommand;
 use Trompette\FeatureToggles\Console\ConfigureFeatureCommand;
 use Trompette\FeatureToggles\Console\MigrateDBALSchemaCommand;
 use Trompette\FeatureToggles\Console\ShowFeatureConfigurationCommand;
@@ -114,6 +115,12 @@ final class FeatureTogglesExtension extends Extension
 
         $container
             ->register(ConfigureFeatureCommand::class, ConfigureFeatureCommand::class)
+            ->addArgument(new Reference(ToggleRouter::class))
+            ->addTag('console.command')
+        ;
+
+        $container
+            ->register(ClearUnregisteredFeaturesCommand::class, ClearUnregisteredFeaturesCommand::class)
             ->addArgument(new Reference(ToggleRouter::class))
             ->addTag('console.command')
         ;

--- a/sources/Console/ClearUnregisteredFeaturesCommand.php
+++ b/sources/Console/ClearUnregisteredFeaturesCommand.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Trompette\FeatureToggles\Console;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Trompette\FeatureToggles\ToggleRouterInterface;
+
+final class ClearUnregisteredFeaturesCommand extends Command
+{
+    private ToggleRouterInterface $toggleRouter;
+
+    public function __construct(ToggleRouterInterface $toggleRouter)
+    {
+        parent::__construct('feature-toggles:clear-unregistered-features');
+
+        $this->toggleRouter = $toggleRouter;
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Clear configuration for unregistered features');
+        $this->setHelp(
+<<<HELP
+The <info>%command.name%</info> command will clear the configuration for all
+unregistered features.
+HELP
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $features = $this->toggleRouter->listUnregisteredFeatures();
+
+        if (empty($features)) {
+            $io->info('No unregistered feature found.');
+
+            return 0;
+        }
+
+        $count = count($features);
+
+        $io->note(sprintf(
+            '%d unregistered feature(s) have been found: %s.',
+            $count,
+            implode(', ', $features),
+        ));
+
+        $question = sprintf(
+            'WARNING! You are about to clear configuration for %d unregistered feature(s). Are you sure you wish to continue?',
+            $count,
+        );
+
+        if (!$this->canExecute($question, $input, $io)) {
+            $io->error('No feature configuration has been cleared.');
+
+            return 1;
+        }
+
+        foreach ($features as $feature) {
+            $this->toggleRouter->clearFeatureConfiguration($feature);
+        }
+
+        $io->success(sprintf(
+            'Successfully cleared configuration for %d feature(s): %s.',
+            $count,
+            implode(', ', $features),
+        ));
+
+        return 0;
+    }
+
+    private function canExecute(string $question, InputInterface $input, SymfonyStyle $io): bool
+    {
+        return !$input->isInteractive() || $io->confirm($question);
+    }
+}

--- a/sources/DBAL/OnOffStrategyConfigurationRepository.php
+++ b/sources/DBAL/OnOffStrategyConfigurationRepository.php
@@ -2,6 +2,7 @@
 
 namespace Trompette\FeatureToggles\DBAL;
 
+use Assert\Assert;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Schema\Schema;
@@ -15,6 +16,27 @@ final class OnOffStrategyConfigurationRepository extends SchemaMigrator implemen
         $sql = 'select enabled from feature_toggles_onoff where feature = ?';
 
         return (bool) $this->connection->fetchOne($sql, [$feature]);
+    }
+
+    public function listFeatures(): array
+    {
+        $sql = 'select distinct feature from feature_toggles_onoff';
+
+        $features = $this->connection->fetchFirstColumn($sql);
+
+        Assert::thatAll($features)->string();
+
+        return $features;
+    }
+
+    public function removefeature(string $feature): void
+    {
+        $this->connection->delete(
+            'feature_toggles_onoff',
+            [
+                'feature' => $feature,
+            ]
+        );
     }
 
     public function setEnabled(bool $enabled, string $feature): void

--- a/sources/DBAL/PercentageStrategyConfigurationRepository.php
+++ b/sources/DBAL/PercentageStrategyConfigurationRepository.php
@@ -2,6 +2,7 @@
 
 namespace Trompette\FeatureToggles\DBAL;
 
+use Assert\Assert;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;
@@ -15,6 +16,27 @@ final class PercentageStrategyConfigurationRepository extends SchemaMigrator imp
         $column = $this->connection->fetchOne($sql, [$feature]);
 
         return false !== $column ? (int) filter_var($column, FILTER_SANITIZE_NUMBER_INT) : 0;
+    }
+
+    public function listFeatures(): array
+    {
+        $sql = 'select distinct feature from feature_toggles_percentage';
+
+        $features = $this->connection->fetchFirstColumn($sql);
+
+        Assert::thatAll($features)->string();
+
+        return $features;
+    }
+
+    public function removefeature(string $feature): void
+    {
+        $this->connection->delete(
+            'feature_toggles_percentage',
+            [
+                'feature' => $feature,
+            ]
+        );
     }
 
     public function setPercentage(int $percentage, string $feature): void

--- a/sources/DBAL/WhitelistStrategyConfigurationRepository.php
+++ b/sources/DBAL/WhitelistStrategyConfigurationRepository.php
@@ -21,6 +21,27 @@ final class WhitelistStrategyConfigurationRepository extends SchemaMigrator impl
         return $targets;
     }
 
+    public function listFeatures(): array
+    {
+        $sql = 'select distinct feature from feature_toggles_whitelist';
+
+        $features = $this->connection->fetchFirstColumn($sql);
+
+        Assert::thatAll($features)->string();
+
+        return $features;
+    }
+
+    public function removefeature(string $feature): void
+    {
+        $this->connection->delete(
+            'feature_toggles_whitelist',
+            [
+                'feature' => $feature,
+            ]
+        );
+    }
+
     public function addToWhitelist(string $target, string $feature): void
     {
         $this->connection->insert('feature_toggles_whitelist', [

--- a/sources/FeatureRegistry.php
+++ b/sources/FeatureRegistry.php
@@ -31,4 +31,12 @@ final class FeatureRegistry
 
         return $this->definitions[$feature];
     }
+
+    /**
+     * @return array<string, FeatureDefinition>
+     */
+    public function getDefinitions(): array
+    {
+        return $this->definitions;
+    }
 }

--- a/sources/OnOffStrategy/ConfigurationRepository.php
+++ b/sources/OnOffStrategy/ConfigurationRepository.php
@@ -7,4 +7,11 @@ interface ConfigurationRepository
     public function isEnabled(string $feature): bool;
 
     public function setEnabled(bool $enabled, string $feature): void;
+
+    /**
+     * @return string[]
+     */
+    public function listFeatures(): array;
+
+    public function removeFeature(string $feature): void;
 }

--- a/sources/OnOffStrategy/OnOff.php
+++ b/sources/OnOffStrategy/OnOff.php
@@ -32,4 +32,14 @@ final class OnOff implements TogglingStrategy
     {
         $this->configurationRepository->setEnabled(false, $feature);
     }
+
+    public function listFeatures(): array
+    {
+        return $this->configurationRepository->listFeatures();
+    }
+
+    public function clearFeatureConfiguration(string $feature): void
+    {
+        $this->configurationRepository->removeFeature($feature);
+    }
 }

--- a/sources/PercentageStrategy/ConfigurationRepository.php
+++ b/sources/PercentageStrategy/ConfigurationRepository.php
@@ -7,4 +7,11 @@ interface ConfigurationRepository
     public function getPercentage(string $feature): int;
 
     public function setPercentage(int $percentage, string $feature): void;
+
+    /**
+     * @return string[]
+     */
+    public function listFeatures(): array;
+
+    public function removeFeature(string $feature): void;
 }

--- a/sources/PercentageStrategy/Percentage.php
+++ b/sources/PercentageStrategy/Percentage.php
@@ -41,6 +41,16 @@ final class Percentage implements TogglingStrategy
         $this->configurationRepository->setPercentage($percentage, $feature);
     }
 
+    public function listFeatures(): array
+    {
+        return $this->configurationRepository->listFeatures();
+    }
+
+    public function clearFeatureConfiguration(string $feature): void
+    {
+        $this->configurationRepository->removeFeature($feature);
+    }
+
     private function computeHash(string $raw, string $salt): int
     {
         return hexdec(substr(md5($raw . $salt), 0, 8)) % 100;

--- a/sources/ToggleRouter.php
+++ b/sources/ToggleRouter.php
@@ -97,4 +97,28 @@ final class ToggleRouter implements LoggerAwareInterface, ToggleRouterInterface
             'parameters' => $parameters,
         ]);
     }
+
+    public function listUnregisteredFeatures(): array
+    {
+        $configuredFeatures = array_unique(array_reduce(
+            $this->strategies,
+            fn (array $features, TogglingStrategy $strategy) => \array_merge($features, $strategy->listFeatures()),
+            []
+        ));
+
+        $registeredFeatures = array_keys($this->registry->getDefinitions());
+
+        $unregisteredFeatures = array_values(array_diff($configuredFeatures, $registeredFeatures));
+
+        sort($unregisteredFeatures);
+
+        return $unregisteredFeatures;
+    }
+
+    public function clearFeatureConfiguration(string $feature): void
+    {
+        foreach ($this->strategies as $strategy) {
+            $strategy->clearFeatureConfiguration($feature);
+        }
+    }
 }

--- a/sources/ToggleRouterInterface.php
+++ b/sources/ToggleRouterInterface.php
@@ -15,4 +15,11 @@ interface ToggleRouterInterface
      * @param mixed $parameters
      */
     public function configureFeature(string $feature, string $strategy, string $method, $parameters = []): void;
+
+    /**
+     * @return string[]
+     */
+    public function listUnregisteredFeatures(): array;
+
+    public function clearFeatureConfiguration(string $feature): void;
 }

--- a/sources/TogglingStrategy.php
+++ b/sources/TogglingStrategy.php
@@ -10,4 +10,11 @@ interface TogglingStrategy
     public function getConfiguration(string $feature): array;
 
     public function decideIfTargetHasFeature(string $target, string $feature): bool;
+
+    /**
+     * @return string[]
+     */
+    public function listFeatures(): array;
+
+    public function clearFeatureConfiguration(string $feature): void;
 }

--- a/sources/WhitelistStrategy/ConfigurationRepository.php
+++ b/sources/WhitelistStrategy/ConfigurationRepository.php
@@ -12,4 +12,11 @@ interface ConfigurationRepository
     public function addToWhitelist(string $target, string $feature): void;
 
     public function removeFromWhitelist(string $target, string $feature): void;
+
+    /**
+     * @return string[]
+     */
+    public function listFeatures(): array;
+
+    public function removeFeature(string $feature): void;
 }

--- a/sources/WhitelistStrategy/Whitelist.php
+++ b/sources/WhitelistStrategy/Whitelist.php
@@ -34,4 +34,14 @@ final class Whitelist implements TogglingStrategy
     {
         $this->configurationRepository->removeFromWhitelist($target, $feature);
     }
+
+    public function listFeatures(): array
+    {
+        return $this->configurationRepository->listFeatures();
+    }
+
+    public function clearFeatureConfiguration(string $feature): void
+    {
+        $this->configurationRepository->removeFeature($feature);
+    }
 }

--- a/tests/Console/ClearUnregisteredFeaturesCommandTest.php
+++ b/tests/Console/ClearUnregisteredFeaturesCommandTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Test\Trompette\FeatureToggles\Console;
+
+use Prophecy\PhpUnit\ProphecyTrait;
+use Symfony\Component\Console\Tester\CommandTester;
+use Trompette\FeatureToggles\Console\ClearUnregisteredFeaturesCommand;
+use PHPUnit\Framework\TestCase;
+use Trompette\FeatureToggles\ToggleRouterInterface;
+
+class ClearUnregisteredFeaturesCommandTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testCommandCanBeExecuted(): void
+    {
+        $toggleRouter = $this->prophesize(ToggleRouterInterface::class);
+        $toggleRouter->listUnregisteredFeatures()->willReturn(['feature_1', 'feature_2']);
+        $toggleRouter->clearFeatureConfiguration('feature_1')->shouldBeCalled();
+        $toggleRouter->clearFeatureConfiguration('feature_2')->shouldBeCalled();
+
+        $commandTester = new CommandTester(new ClearUnregisteredFeaturesCommand($toggleRouter->reveal()));
+        $commandTester->execute($input = []);
+
+        static::assertSame(0, $commandTester->getStatusCode());
+        static::assertStringContainsString('2 unregistered feature(s) have been found', $commandTester->getDisplay());
+        static::assertStringContainsString('Successfully cleared configuration for 2 feature(s): feature_1, feature_2.', $commandTester->getDisplay());
+    }
+}

--- a/tests/DBAL/OnOffStrategyConfigurationRepositoryTest.php
+++ b/tests/DBAL/OnOffStrategyConfigurationRepositoryTest.php
@@ -25,4 +25,17 @@ class OnOffStrategyConfigurationRepositoryTest extends ConfigurationRepositoryTe
         $this->repository->setEnabled(false, 'feature');
         static::assertFalse($this->repository->isEnabled('feature'));
     }
+
+    public function testListAndRemoveFeatures(): void
+    {
+        $this->repository->migrateSchema();
+        static::assertEmpty($this->repository->listFeatures());
+
+        $this->repository->setEnabled(true, 'feature_1');
+        $this->repository->setEnabled(false, 'feature_2');
+        static::assertSame(['feature_1', 'feature_2'], $this->repository->listFeatures());
+
+        $this->repository->removeFeature('feature_1');
+        static::assertSame(['feature_2'], $this->repository->listFeatures());
+    }
 }

--- a/tests/DBAL/PercentageStrategyConfigurationRepositoryTest.php
+++ b/tests/DBAL/PercentageStrategyConfigurationRepositoryTest.php
@@ -22,4 +22,17 @@ class PercentageStrategyConfigurationRepositoryTest extends ConfigurationReposit
         $this->repository->setPercentage(25, 'feature');
         static::assertSame(25, $this->repository->getPercentage('feature'));
     }
+
+    public function testListAndRemoveFeatures(): void
+    {
+        $this->repository->migrateSchema();
+        static::assertEmpty($this->repository->listFeatures());
+
+        $this->repository->setPercentage(10, 'feature_1');
+        $this->repository->setPercentage(50, 'feature_2');
+        static::assertSame(['feature_1', 'feature_2'], $this->repository->listFeatures());
+
+        $this->repository->removeFeature('feature_1');
+        static::assertSame(['feature_2'], $this->repository->listFeatures());
+    }
 }

--- a/tests/DBAL/WhitelistStrategyConfigurationRepositoryTest.php
+++ b/tests/DBAL/WhitelistStrategyConfigurationRepositoryTest.php
@@ -25,4 +25,18 @@ class WhitelistStrategyConfigurationRepositoryTest extends ConfigurationReposito
         $this->repository->removeFromWhitelist('target', 'feature');
         static::assertEmpty($this->repository->getWhitelistedTargets('feature'));
     }
+
+    public function testListAndRemoveFeatures(): void
+    {
+        $this->repository->migrateSchema();
+        static::assertEmpty($this->repository->listFeatures());
+
+        $this->repository->addToWhitelist('target_a', 'feature_1');
+        $this->repository->addToWhitelist('target_a', 'feature_2');
+        $this->repository->addToWhitelist('target_b', 'feature_2');
+        static::assertSame(['feature_1', 'feature_2'], $this->repository->listFeatures());
+
+        $this->repository->removeFeature('feature_1');
+        static::assertSame(['feature_2'], $this->repository->listFeatures());
+    }
 }

--- a/tests/FeatureRegistryTest.php
+++ b/tests/FeatureRegistryTest.php
@@ -25,4 +25,16 @@ class FeatureRegistryTest extends TestCase
         $registry->register(new FeatureDefinition('feature', 'awesome feature', 'strategy'));
         $registry->register(new FeatureDefinition('feature', 'awesome feature', 'strategy'));
     }
+
+    public function testGetDefinitionsKeyedByFeatureName(): void
+    {
+        $registry = new FeatureRegistry();
+        $registry->register(new FeatureDefinition('feature_1', 'awesome feature', 'strategy'));
+        $registry->register(new FeatureDefinition('feature_2', 'another awesome feature', 'strategy'));
+
+        $definitions = $registry->getDefinitions();
+
+        static::assertContainsOnlyInstancesOf(FeatureDefinition::class, $definitions);
+        static::assertSame(['feature_1', 'feature_2'], \array_keys($definitions));
+    }
 }

--- a/tests/ToggleRouterTest.php
+++ b/tests/ToggleRouterTest.php
@@ -144,6 +144,49 @@ class ToggleRouterTest extends TestCase
         static::assertTrue($router->hasFeature('target', 'feature'));
     }
 
+    public function testListUnregisteredFeatures(): void
+    {
+        $router = $this->configureToggleRouter(
+            new FeatureDefinition('feature', 'awesome feature', 'onoff or whitelist or percentage'),
+            $this->configureAllStrategies()
+        );
+
+        $router->configureFeature('feature', 'whitelist', 'allow', 'target');
+        $router->configureFeature('unregistered', 'whitelist', 'allow', 'target');
+        $router->configureFeature('unregistered', 'percentage', 'slide', '50');
+
+        static::assertSame(['unregistered'], $router->listUnregisteredFeatures());
+    }
+
+    public function testConfigurationCanBeClearedForRegisteredFeatures(): void
+    {
+        $router = $this->configureToggleRouter(
+            new FeatureDefinition('feature', 'awesome feature', 'onoff or whitelist or percentage'),
+            $this->configureAllStrategies()
+        );
+
+        $router->configureFeature('feature', 'whitelist', 'allow', 'target');
+
+        static::assertTrue($router->hasFeature('target', 'feature'));
+
+        $router->clearFeatureConfiguration('feature');
+
+        static::assertFalse($router->hasFeature('target', 'feature'));
+    }
+
+    public function testConfigurationCanBeClearedForUnregisteredFeatures(): void
+    {
+        $router = $this->configureToggleRouter(null, $this->configureAllStrategies());
+
+        $router->configureFeature('feature', 'whitelist', 'allow', 'target');
+
+        static::assertSame(['feature'], $router->listUnregisteredFeatures());
+
+        $router->clearFeatureConfiguration('feature');
+
+        static::assertEmpty($router->listUnregisteredFeatures());
+    }
+
     /**
      * @param array<string, TogglingStrategy> $strategies
      */


### PR DESCRIPTION
closes https://github.com/trompette/php-feature-toggles/issues/46

This PR adds a console command to clear configuration for all unregistered features:

![image](https://github.com/trompette/php-feature-toggles/assets/1181770/94aefd7c-ba9d-4821-a560-0ffdd5a4e0a2)
