### PR TITLE
Fix implicitly nullable parameter declaration deprecation

### DIFF
--- a/tests/ToggleRouterTest.php
+++ b/tests/ToggleRouterTest.php
@@ -147,7 +147,7 @@ class ToggleRouterTest extends TestCase
     /**
      * @param array<string, TogglingStrategy> $strategies
      */
-    private function configureToggleRouter(FeatureDefinition $definition = null, array $strategies = []): ToggleRouter
+    private function configureToggleRouter(?FeatureDefinition $definition = null, array $strategies = []): ToggleRouter
     {
         $registry = new FeatureRegistry();
 


### PR DESCRIPTION
These changes are needed in order to be able to support PHP 8.4.

Ref: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated